### PR TITLE
firestore.rulesもCIからデプロイする

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -15,9 +15,9 @@ jobs:
       - uses: actions/checkout@v2
       - run: npm ci --omit=dev && npm run build
       - run: |
-          gacFilename="$(mktemp)"
-          cat "${{ secrets.FIREBASE_SERVICE_ACCOUNT_SHARE_TIMER_2B51A }}" > "${gacFilename}"
-          GOOGLE_APPLICATION_CREDENTIALS="${gacFilename}" npm run deploy:rules
+          export GOOGLE_APPLICATION_CREDENTIALS="$(mktemp)"
+          echo "${{ secrets.FIREBASE_SERVICE_ACCOUNT_SHARE_TIMER_2B51A }}" > "${GOOGLE_APPLICATION_CREDENTIALS}"
+          npm run deploy:rules
       - uses: FirebaseExtended/action-hosting-deploy@v0
         with:
           repoToken: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
正しくはcat -> echoだった。
gacFilenameという変数を挟む必要がなさそうなのでGOOGLE_APPLICATION_CREDENTIALSをそのまま使った。