### PR TITLE
checkout-sessions のインデックス定義を保持して、ともかくデプロイを成功させる

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -15,5 +15,18 @@
       ]
     }
   ],
-  "fieldOverrides": []
+  "fieldOverrides": [
+    {
+      "collectionGroup": "checkout-sessions-dev",
+      "fieldPath": "payload",
+      "ttl": false,
+      "indexes": []
+    },
+    {
+      "collectionGroup": "checkout-sessions-v1",
+      "fieldPath": "payload",
+      "ttl": false,
+      "indexes": []
+    }
+  ]
 }


### PR DESCRIPTION
firestore.indexes.json に未定義のインデックスは削除する設定でもいいが、このインデックスはすぐ使いそうなので、保持する方向で